### PR TITLE
Some slider changes

### DIFF
--- a/server.R
+++ b/server.R
@@ -26,8 +26,8 @@ server <- function(input, output, session) {
   n  <- reactive(input$n)                          # sample size
   number <- reactive(input$number)                 # number of samples
   specific <- reactive(input$specific)             # specific sample
-  min_uni_priori <- reactive(input$min_uni_priori) # minimum für gleichverteilte priori
-  max_uni_priori <- reactive(input$max_uni_priori) # max für gleichverteilte priori
+  min_uni_priori <- reactive(input$uni_prior_range[1]) # minimum für gleichverteilte priori
+  max_uni_priori <- reactive(input$uni_prior_range[2]) # max für gleichverteilte priori
   mu_prior <-  reactive(input$mu_prior)            # mittelwert der priori
   tau_prior <- reactive(input$tau_prior)           # sd der priori
   lengthout <- 100                                # die Länge von mu_hat, NICHT REAKTIV!

--- a/server.R
+++ b/server.R
@@ -8,6 +8,17 @@ server <- function(input, output, session) {
 
   set.seed(12345)
 
+  ## UI: update "specific" slider, corresponding to input$number
+
+  observe(label = "update_specific_slider", {
+    updateSliderInput(inputId = "specific",
+                      max = input$number,
+                      value = ifelse(test = input$number < input$specific,
+                                     yes = input$number,
+                                     no = input$specific))
+                      # avoid having a value higher than the new max
+  })
+
   #### data ####
   # get input from ui
   mu <- reactive(input$mu)                         # Population mean

--- a/ui.R
+++ b/ui.R
@@ -60,14 +60,13 @@ column(2,     checkboxInput("p_forest", "Forestplot", value = F)),
                 max = 1000,
                 value = 10),
 
-    # Specific Sample
+    # Specific Sample: Dynamic Max depending on "number" (see server.R)
     sliderInput(inputId = "specific",
-                "Spezifische Stichprobe",
-                min = 0,
-                max = 1000,
+                label = "Spezifische Stichprobe",
+                max = 10,
+                min = 1,
+                step = 1,
                 value = 3),
-
-
 
     #### Priors ####
     # Gleichverteiler Prior

--- a/ui.R
+++ b/ui.R
@@ -70,21 +70,14 @@ column(2,     checkboxInput("p_forest", "Forestplot", value = F)),
 
     #### Priors ####
     # Gleichverteiler Prior
-    # Minimum
-    sliderInput(inputId = "min_uni_priori",
-                "Minimum der Gleichverteilten Priori",
-                min = -100,
-                max = 100,
-# !!! An Maximum anpassen
-                value = -5),
 
-    # Maximum
-    sliderInput(inputId = "max_uni_priori",
-                "Maximum der Gleichverteilten Priori",
+    sliderInput("uni_prior_range",
+                "Minimum und Maximum der Gleichverteilten Priori",
+                dragRange = TRUE,
                 min = -100,
                 max = 100,
-  # !!! An Minimum anpassen
-                value = 0),
+                value = c(-10, 0),
+                step = 1),
 
 
     # Normalverteilter Prior


### PR DESCRIPTION
### Specific Slider 

**Situation:** `input$specific` can currently be higher than `input$number`
**Suggestion:** dynamically change the `max` argument of `input$specific` slider

**Changes:**
- `server.R`: 
  add observer to update the slider max if input$number changes. Also update the value, if it would be greater than the new slider max

- `ui.R`: 
  add stepsize = 1
  change start `max` to 10 to correspond to the default value of `input$number` = 10

### Uniform Priori Min/Max Sliders

**Situation**: Min can be higher than Max for the uniform priori distribution
**Suggestion**: Use one range slider instead of two separate sliders

**Changes**: See https://github.com/gesagraf/spielkram/pull/1/commits/8bb107fe409f48afe0fb697aee4fa6c41193c867
